### PR TITLE
Add "export GTK_THEME=adw-gtk3-dark" to ~/.profile

### DIFF
--- a/etc/skel/.profile
+++ b/etc/skel/.profile
@@ -1,3 +1,4 @@
 export BROWSER=firefox
 export TERM=alacritty
 export QT_QPA_PLATFORMTHEME="qt5ct"
+export GTK_THEME=adw-gtk3-dark


### PR DESCRIPTION
Possible fix for gtk dark mode settings