### PR TITLE
removed DISPLAY from environment for 25.08+

### DIFF
--- a/etc/skel/.config/niri/config.kdl
+++ b/etc/skel/.config/niri/config.kdl
@@ -254,7 +254,6 @@ binds {
 // https://github.com/YaLTeR/niri/wiki/Configuration:-Miscellaneous#environment
 
     environment {
-        DISPLAY ":1"
         ELECTRON_OZONE_PLATFORM_HINT "auto"
         QT_QPA_PLATFORM "wayland"
         QT_WAYLAND_DISABLE_WINDOWDECORATION "1"


### PR DESCRIPTION
DISPLAY not needed from 25.08 on:
"If you had a custom config which manually started xwayland-satellite and set $DISPLAY, you should remove those customizations for the automatic integration to work." https://yalter.github.io/niri/Xwayland.html