### PR TITLE
Change keyboard layout comment to American

### DIFF
--- a/etc/skel/.config/niri/config.kdl
+++ b/etc/skel/.config/niri/config.kdl
@@ -7,7 +7,7 @@
 input {
     keyboard {
         xkb {
-            layout "us" // Use the German keyboard layout
+            layout "us" // Use the American keyboard layout
         }
         numlock // Enable numlock on startup
     }


### PR DESCRIPTION
Just something that wasn't changed when updating the default keyboard layout to "us"